### PR TITLE
Fix typos in section 1.2. of User Guide

### DIFF
--- a/src/docbkx/ug/introduction/first-performance-test/demo-httpbin.xml
+++ b/src/docbkx/ug/introduction/first-performance-test/demo-httpbin.xml
@@ -36,7 +36,7 @@
   </messages>
 </scenario>]]></programlisting>
    </para>
-   <para>As you can see, the simplest scenario runs for 30000ms = 3 seconds. It generates
+   <para>As you can see, the simplest scenario runs for 30000ms = 30 seconds. It generates
       messages/requests using 100 threads and sends them via HTTP to the server specified in a
       property (see below for explanation) using the POST method. Performance test results are
       reported to the console every 1000ms or 1 second. The content of the messages that are being

--- a/src/docbkx/ug/introduction/first-performance-test/quickstart.xml
+++ b/src/docbkx/ug/introduction/first-performance-test/quickstart.xml
@@ -68,11 +68,12 @@ usage: ScenarioExecution -s <SCENARIO> [options] [-D<property=value>]*
          schema that can be found under <code>resources/schemas</code> directory. Some of the
          editors are able to use the schema file to suggest you valid tags. Our future plans include
          providing GUI editor for Eclipse and InteliJ Idea that would allow you to create and edit
-         scenarios, stay tuned! If you wanted to contribute, we are happy to community <footnote>
+         scenarios, stay tuned! If you wanted to contribute, we are happy to welcome you in our
+         community <footnote>
             <para>
                <link xlink:href="https://www.perfcake.org/community"/>
             </para>
-         </footnote> to welcome you in our commmunity. </para>
+         </footnote>. </para>
       <para>
          At minimum, simple scenario has to contain definitions for:
          <itemizedlist>


### PR DESCRIPTION
I have fixed some typos that I have found in section _1.2. Your first performance test_ of User Guide.